### PR TITLE
Fix IndexError for some inputs when creating un_chomsky_normal_form.

### DIFF
--- a/stat_parser/treebanks/normalize.py
+++ b/stat_parser/treebanks/normalize.py
@@ -58,7 +58,7 @@ def un_chomsky_normal_form(tree):
         for i in range(2, len(tree)):
             if sym == tree[i][0]:
                 # Undo (3)
-                tree[i:] = tree[i][1:]
+                tree[i:i+1] = tree[i][1:]
                 transformed = True
         if transformed:
             un_chomsky_normal_form(tree)


### PR DESCRIPTION
A contrived example sentence such as the following throws an error when parsed:

"That o'er the files and musters of the war Have glow'd like plated Mars, now bend, now turn, The office and devotion of their view Upon a tawny front."

``` python
.../stat_parser/treebanks/normalize.pyc in un_chomsky_normal_form(tree)
     57         transformed = False
     58         for i in range(2, len(tree)):
---> 59             if sym == tree[i][0]:
     60                 # Undo (3)
     61                 tree[i:] = tree[i][1:]

IndexError: list index out of range
```
